### PR TITLE
remove bare except by specifying the expected ModuleNotFoundError

### DIFF
--- a/Quellcode/chap_6/keras_version_check.py
+++ b/Quellcode/chap_6/keras_version_check.py
@@ -3,7 +3,7 @@ try:
     import tensorflow as tf
     from tensorflow import keras
     print("Keras TensorFlow version: {}".format(keras.__version__))
-except:
+except ModuleNotFoundError:
     print("Keras TensorFlow Version nicht installiert")
 
 # Wenn Sie zusätzlich Keras über keras.io installiert haben, werden Sie
@@ -14,5 +14,5 @@ except:
 try:
     import keras
     print("Keras version: {}".format(keras.__version__))
-except: 
+except ModuleNotFoundError: 
     print("Keras Version von keras.io nicht installiert")


### PR DESCRIPTION
Mir ist beim Lesen des Buches aufgefallen (vielen Dank erst mal, das Buch ist sehr gut), dass es in Kapitel 6 ein "bare except" gibt. Das sollte zwar in diesem Beispiel kein Riesenproblem sein, aber ist als Referenz für Anfänger vermutlich nicht ideal, da dies alle möglichen Fehler ignorieren würde. Es wäre daher auch sehr schön wenn das hier im Code oder in Neuauflagen des Buches gefixed werden könnte. Hier auch einmal die entsprechende Referenz:
https://peps.python.org/pep-0008/#programming-recommendations
bzw.
https://www.flake8rules.com/rules/E722.html
